### PR TITLE
Update the commit time element from 'time' to 'relative-time'.

### DIFF
--- a/app/github.js
+++ b/app/github.js
@@ -48,7 +48,7 @@ function extractFirstCommitInfo($) {
 
   var author_id = li.find('.commit-author-section a').text().trim();
   var commit_title = li.find('.commit-title a').text().trim();
-  var time_str = li.find('time').attr('datetime');
+  var time_str = li.find('relative-time').attr('datetime');
 
   return {
     repo: repo,


### PR DESCRIPTION
Github have changed the name of the element which contains the commit
time from `<time></time>` to `<relative-time></relative-time>`.

This is resulting in the wrong date for any search that has not already been
cached.
